### PR TITLE
Support Spark 2.4.6 / 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ Build the library using Maven 3.3.9 or newer as shown below:
 git clone https://github.com/linkedin/spark-tfrecord.git
 cd spark-tfrecord
 mvn clean install
-# one can specific the spark version and tensorflow hadoop version
-# mvn clean install -Dspark.version=2.2.1 -Dtensorflow.hadoop.version=1.15.0
+
+# One can specify the spark version and tensorflow hadoop version, for example
+mvn clean install -Dspark.version=2.4.6 -Dtensorflow.hadoop.version=1.15.0
+
+# Or for building with Spark 3, use the following
+mvn clean install -Dspark.version=3.0.0 -Dscala.binary.version=2.12 -Dscala.compiler.version=2.12.11  -Dscala.test.version=3.0.0
+# In this instance we would suggest changing the `<artifactId>` in the `pom.xml` to spark-tfrecord_2.12
 ```
 
 After installation (or deployment), the package can be used with the following dependency:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>
@@ -21,11 +21,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.maven.version>3.2.2</scala.maven.version>
         <scala.binary.version>2.11</scala.binary.version>
+        <scala.compiler.version>2.11.8</scala.compiler.version>
         <scalatest.maven.version>1.0</scalatest.maven.version>
         <scala.test.version>2.2.6</scala.test.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.4.6</spark.version>
         <junit.version>4.11</junit.version>
         <tensorflow.hadoop.version>1.15.0</tensorflow.hadoop.version>
     </properties>
@@ -78,7 +79,7 @@
                     <configuration>
                         <recompileMode>incremental</recompileMode>
                         <useZincServer>true</useZincServer>
-                        <scalaVersion>${scala.binary.version}</scalaVersion>
+                        <scalaVersion>${scala.compiler.version}</scalaVersion>
                         <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
                     </configuration>
                 </plugin>

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -35,9 +35,9 @@ object TFRecordFileReader {
     // Ensure that the reader is closed even if the task fails or doesn't consume the entire
     // iterator of records.
     Option(TaskContext.get()).foreach { taskContext =>
-      taskContext.addTaskCompletionListener { _ =>
+      taskContext.addTaskCompletionListener[Unit]((_: TaskContext) =>
         recordReader.close()
-      }
+      )
     }
 
     recordReader.initialize(inputSplit, hadoopAttemptContext)


### PR DESCRIPTION
This PR contains the following changes:

- Modify the pom.xml to differentiate between the specific compiler version used (e.g. 2.11.8) and the binary compatibility version (e.g. 2.11)
- Bump the Spark version to 2.4.6 (the final Spark 2.x release
- Add instructions for building this package for Spark 3.0.0

