### PR TITLE
Use non-empty file for schema inference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>


### PR DESCRIPTION
Sometime of the part files can be empty. Instead of using the first file for schema inference which can cause empty schema, this patch uses the first non-empty file for this purpose.