### PR TITLE
Use non-empty file for schema inference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>


### PR DESCRIPTION
same as https://github.com/linkedin/spark-tfrecord/pull/6, but on master branch.