### PR TITLE
Use NullType when inferring column where every feature has an empty list

### DIFF
--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TensorFlowInferSchema.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TensorFlowInferSchema.scala
@@ -47,7 +47,7 @@ object TensorFlowInferSchema {
     val columnsList = rootTypes.map {
       case (featureName, featureType) =>
         if (featureType == null) {
-          StructField(featureName, StringType)
+          StructField(featureName, NullType)
         }
         else {
           StructField(featureName, featureType)


### PR DESCRIPTION
## Problem
We have an issue when deserializing tfrecords. The problem seems to exist within `TensorFlowInferSchema`.

Let say we have a column `col` of type `Array[Float]`. When every single element of `col` is an empty list, the StructField will be inferred to a StringType (see [here](https://github.com/linkedin/spark-tfrecord/blob/276e90a4aa5fac101512a75eeadb3497aea66910/src/main/scala/com/linkedin/spark/datasources/tfrecord/TensorFlowInferSchema.scala#L50)). Once we start deserializing, we will hit [this](https://github.com/linkedin/spark-tfrecord/blob/276e90a4aa5fac101512a75eeadb3497aea66910/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializer.scala#L185) line, resulting in a failed job. 

## Solution
I suggest we change it to the more appropriate `NullType`. The deserialization already handles that type quite nicely and it solves the issue for us.