### PR TITLE
Proposal to target Spark 3.0.0 and Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ jdk:
 
 matrix:
   include:
-    - scala: 2.11.12
-      script: "mvn test -B -Pscala-2.11"
-
     - scala: 2.12.12
       script: "mvn test -B -Pscala-2.12"
+
+#    - scala: 2.13.3
+#      script: "mvn test -B -Pscala-2.13"
 
 # safelist
 branches:

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ The artifacts are published to [bintray](https://bintray.com/linkedin/maven/spar
 
 - Version 0.1.x targets Spark 2.3 and Scala 2.11
 - Version 0.2.x targets Spark 2.4 and both Scala 2.11 and 2.12
+- Version 0.3.x targets Spark 3.0 and Scala 2.12
 
 To use the package, please include the dependency as follows
 
 ```xml
 <dependency>
   <groupId>com.linkedin.sparktfrecord</groupId>
-  <artifactId>spark-tfrecord_2.11</artifactId>
+  <artifactId>spark-tfrecord_2.12</artifactId>
   <version>your.version</version>
 </dependency>
 ```
@@ -27,20 +28,17 @@ The library can be built with Maven 3.3.9 or newer as shown below:
 # Build Spark-TFRecord
 git clone https://github.com/linkedin/spark-tfrecord.git
 cd spark-tfrecord
-mvn -Pscala-2.11 clean install
+mvn -Pscala-2.12 clean install
 
 # One can specify the spark version and tensorflow hadoop version, for example
-mvn -Pscala-2.11 clean install -Dspark.version=2.4.6 -Dtensorflow.hadoop.version=1.15.0
-
-# Or for building with Spark 3, use the following
-mvn -Pscala-2.12 clean install -Dspark.version=3.0.0
+mvn -Pscala-2.12 clean install -Dspark.version=3.0.0 -Dtensorflow.hadoop.version=1.15.0
 ```
 
 ## Using Spark Shell
 Run this library in Spark using the `--jars` command line option in `spark-shell`, `pyspark` or `spark-submit`. For example:
 
 ```sh
-$SPARK_HOME/bin/spark-shell --jars target/spark-tfrecord_2.11-0.1.1.jar
+$SPARK_HOME/bin/spark-shell --jars target/spark-tfrecord_2.12-0.3.0.jar
 ```
 
 ## Features
@@ -98,7 +96,7 @@ The supported Spark data types are listed in the table below:
 
 Run PySpark with the spark_connector in the jars argument as shown below:
 
-`$SPARK_HOME/bin/pyspark --jars target/spark-tfrecord_2.11-0.1.1.jar`
+`$SPARK_HOME/bin/pyspark --jars target/spark-tfrecord_2.12-0.3.0.jar`
 
 The following Python code snippet demonstrates usage on test data.
 
@@ -123,7 +121,7 @@ df.show()
 ### Scala API
 Run Spark shell with the spark_connector in the jars argument as shown below:
 ```sh
-$SPARK_HOME/bin/spark-shell --jars target/spark-tfrecord_2.11-0.1.1.jar
+$SPARK_HOME/bin/spark-shell --jars target/spark-tfrecord_2.12-0.3.0.jar
 ```
 
 The following Scala code snippet demonstrates usage on test data.
@@ -168,7 +166,7 @@ The following example shows to how to use partitionBy, which is not supported by
 ```scala
 
 // launch spark-shell with the following command:
-// SPARK_HOME/bin/spark-shell --jar target/spark-tfrecord_2.11-0.1.1.jar
+// SPARK_HOME/bin/spark-shell --jar target/spark-tfrecord_2.12-0.3.0.jar
 
 import org.apache.spark.sql.SaveMode
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.3</version>
+    <version>0.3.0</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>
@@ -30,7 +30,7 @@
         <scala.maven.version>3.2.2</scala.maven.version>
         <scalatest.maven.version>1.0</scalatest.maven.version>
         <scala.test.version>3.0.8</scala.test.version>
-        <spark.version>2.4.6</spark.version>
+        <spark.version>3.0.0</spark.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
         <junit.version>4.11</junit.version>
@@ -339,18 +339,22 @@
         </profile>
 
         <profile>
-            <id>scala-2.11</id>
-            <properties>
-                <scala.binary.version>2.11</scala.binary.version>
-                <scala.version>2.11.12</scala.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>scala-2.12</id>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.12</scala.version>
+            </properties>
+        </profile>
+
+        <!-- Note this does not work yet and should not be used.
+             Spark 3.0.x on Scala 2.13 is close, but not ready yet.
+             It may only be ready for Spark 3.1.x
+             See: https://github.com/apache/spark/pull/29147 -->
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+                <scala.version>2.13.13</scala.version>
             </properties>
         </profile>
 


### PR DESCRIPTION
This is a proposal to release an artifact for Spark 3.0.0 and Scala 2.12.

I would propose to have this on a different branch to master and a different minor version number (0.3.x). This PR is referencing the master branch because there isn't a different branch to target.

I think many users on Spark 3.0.0 would appreciate this artifact being published, even if it is made clear that it is not officially supported. We can add some clarification in the README. I also do not believe that it will be a significant burden to maintain both the master branch and some `0.3.x` branch until you are comfortable having Spark 3.0.0 in the master branch.

Ultimately, I can imagine that in future Spark 3.0.0 will compile and run on both Scala 2.12 and 2.13. Certainly this will be the case from Spark 3.1.x.

I just threw this quickly together to get your thoughts and opinions. I know we did recently merge the Scala 2.12 support for Spark 2.4.x, so I hope this isn't too annoying for you to consider. :)