### PR TITLE
Enable compatibility with OCI HDFS Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.1</version>
+    <version>0.3.3</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
@@ -36,7 +36,7 @@ class TFRecordOutputWriter(
   }
 
   override def close(): Unit = {
-    outputStream.close()
     dataOutputStream.close()
+    outputStream.close()
   }
 }


### PR DESCRIPTION
The current version of the .jar breaks with the oci hdfs connector (https://github.com/oracle/oci-hdfs-connector) as the outputstream is also flushed from within the connector. Reversing the order fixes this problem