### PR TITLE
Support Byte Array write output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ compression. While reading compressed TensorFlow records, `codec` can be inferre
 * `recordType`: output format of TensorFlow records. By default it is Example. Possible values are:
   * `Example`: TensorFlow [Example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records
   * `SequenceExample`: TensorFlow [SequenceExample](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records
+  * `ByteArray`: `Array[Byte]` type in scala. For use cases when writing objects other than tensorflow Example or SequenceExample. For example, [protos](https://developers.google.com/protocol-buffers) can be transformed to byte arrays using `.toByteArray`.
 
 The writer support partitionBy operation. So the following command will partition the output by "partitionColumn".
 ```

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
@@ -25,14 +25,16 @@ class TFRecordOutputWriter(
 
   override def write(row: InternalRow): Unit = {
     val record = recordType match {
+      case "ByteArray" =>
+        serializer.serializeByteArray(row)
       case "Example" =>
-        serializer.serializeExample(row)
+        serializer.serializeExample(row).toByteArray
       case "SequenceExample" =>
-        serializer.serializeSequenceExample(row)
+        serializer.serializeSequenceExample(row).toByteArray
       case _ =>
-        throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be Example or SequenceExample")
+        throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be Byte Array, Example or SequenceExample")
     }
-    writer.write(record.toByteArray)
+    writer.write(record)
   }
 
   override def close(): Unit = {

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordSerializer.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordSerializer.scala
@@ -13,6 +13,10 @@ class TFRecordSerializer(dataSchema: StructType) {
 
   private val featureConverters = dataSchema.map(_.dataType).map(newFeatureConverter(_)).toArray
 
+  def serializeByteArray(row: InternalRow): Array[Byte] = {
+    row.getBinary(0)
+  }
+  
   def serializeExample(row: InternalRow): Example = {
     val features = Features.newBuilder()
     val example = Example.newBuilder()

--- a/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordSerializerTest.scala
+++ b/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordSerializerTest.scala
@@ -30,6 +30,18 @@ class TFRecordSerializerTest extends WordSpec with Matchers {
   private def createArray(values: Any*): ArrayData = new GenericArrayData(values.toArray)
 
   "Serialize spark internalRow to tfrecord" should {
+    
+    "Serialize ByteArray internalRow to ByteArray" in {
+      val serializer = new TFRecordSerializer(new StructType())
+
+      val byteArray = Array[Byte](0xde.toByte, 0xad.toByte, 0xbe.toByte, 0xef.toByte)
+      val internalRow = InternalRow(byteArray)
+      val serializedByteArray = serializer.serializeByteArray(internalRow)
+
+      //two byte arrays should be the same, since serialization just gets byte array from internal row
+      assert(byteArray.length == serializedByteArray.length)
+      assert(byteArray.sameElements(serializedByteArray))
+    }
 
     "Serialize  decimal internalRow to tfrecord example" in {
       val schemaStructType = StructType(Array(


### PR DESCRIPTION
For use cases like serializing protos (or other object types) to tfrecord files, users can directly provide byte arrays as write output, and not limit to TFExample. 