### PR TITLE
make spark 3.4.0 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The artifacts are published to [bintray](https://bintray.com/linkedin/maven/spar
 - Version 0.3.x targets Spark 3.0 and Scala 2.12
 - Version 0.4.x targets Spark 3.2 and Scala 2.12
 - Version 0.5.x targets Spark 3.2 and Scala 2.13
+- Version 0.6.x targets Spark 3.4 and Scala 2.12
+- Version 0.7.x targets Spark 3.4 and Scala 2.13
 
 To use the package, please include the dependency as follows
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <scala.maven.version>3.2.2</scala.maven.version>
         <scalatest.maven.version>1.0</scalatest.maven.version>
         <scala.test.version>3.0.8</scala.test.version>
-        <spark.version>3.2.0</spark.version>
+        <spark.version>3.4.0</spark.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
         <junit.version>4.13.1</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.linkedin.sparktfrecord</groupId>
     <artifactId>spark-tfrecord_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.1</version>
+    <version>0.6.0</version>
     <name>spark-tfrecord</name>
     <url>https://github.com/linkedin/spark-tfrecord</url>
     <description>TensorFlow TFRecord data source for Apache Spark</description>

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -1,7 +1,7 @@
 package com.linkedin.spark.datasources.tfrecord
 
-import java.net.URI
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -23,7 +23,7 @@ object TFRecordFileReader {
     val recordType = options.getOrElse("recordType", "Example")
 
     val inputSplit = new FileSplit(
-      new Path(new URI(file.filePath)),
+      file.toPath,
       file.start,
       file.length,
       // The locality is decided by `getPreferredLocations` in `FileScanRDD`.

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -2,7 +2,6 @@ package com.linkedin.spark.datasources.tfrecord
 
 import java.net.URI
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl


### PR DESCRIPTION
Makes TFRecordFileReader.scala compatible with spark 3.4.0's `SparkPath`.