### PR TITLE
Adding support for reading ByteArray's from TFRecord files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ When reading TensorFlow records into Spark DataFrame, the API accepts several op
 * `recordType`: input format of TensorFlow records. By default it is Example. Possible values are:
   * `Example`: TensorFlow [Example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records
   * `SequenceExample`: TensorFlow [SequenceExample](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records
+  * `ByteArray`: `Array[Byte]` type in scala.
 
 When writing Spark DataFrame to TensorFlow records, the API accepts several options:
 * `save`: output path to TensorFlow records. Output path to TensorFlow records on local or distributed filesystem.

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/DefaultSource.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/DefaultSource.scala
@@ -52,6 +52,8 @@ class DefaultSource extends FileFormat with DataSourceRegister {
     val rdd = sparkSession.sparkContext.newAPIHadoopFile(file.getPath.toString,
       classOf[TFRecordFileInputFormat], classOf[BytesWritable], classOf[NullWritable])
     recordType match {
+      case "ByteArray" =>
+        TensorFlowInferSchema.getSchemaForByteArray()
       case "Example" =>
         val exampleRdd = rdd.map{case (bytesWritable, nullWritable) =>
           Example.parseFrom(bytesWritable.getBytes)
@@ -63,7 +65,7 @@ class DefaultSource extends FileFormat with DataSourceRegister {
         }
         TensorFlowInferSchema(sequenceExampleRdd)
       case _ =>
-        throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be Example or SequenceExample")
+        throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be ByteArray, Example or SequenceExample")
     }
   }
 

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializer.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializer.scala
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters._
  */
 class TFRecordDeserializer(dataSchema: StructType) {
 
-  def deserializeByteArray(byteArray: Array[Byte]) = {
+  def deserializeByteArray(byteArray: Array[Byte]): InternalRow = {
     InternalRow(byteArray)
   }
 

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializer.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializer.scala
@@ -14,6 +14,10 @@ import scala.jdk.CollectionConverters._
  */
 class TFRecordDeserializer(dataSchema: StructType) {
 
+  def deserializeByteArray(byteArray: Array[Byte]) = {
+    InternalRow(byteArray)
+  }
+
   def deserializeExample(example: Example): InternalRow = {
     val featureMap = example.getFeatures.getFeatureMap.asScala
     val resultRow = new SpecificInternalRow(dataSchema.map(_.dataType))

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -67,6 +67,8 @@ object TFRecordFileReader {
         havePair = false
         val bytesWritable = recordReader.getCurrentKey
         recordType match {
+          case "ByteArray" =>
+            deserializer.deserializeByteArray(bytesWritable.getBytes)
           case "Example" =>
             val example = Example.parseFrom(bytesWritable.getBytes)
             deserializer.deserializeExample(example)
@@ -74,7 +76,7 @@ object TFRecordFileReader {
             val sequenceExample = SequenceExample.parseFrom(bytesWritable.getBytes)
             deserializer.deserializeSequenceExample(sequenceExample)
           case _ =>
-            throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be Example or SequenceExample")
+            throw new IllegalArgumentException(s"Unsupported recordType ${recordType}: recordType can be ByteArray, Example or SequenceExample")
         }
       }
     }

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TensorFlowInferSchema.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TensorFlowInferSchema.scala
@@ -57,6 +57,12 @@ object TensorFlowInferSchema {
     StructType(columnsList.toSeq)
   }
 
+  def getSchemaForByteArray() : StructType = {
+    StructType(Array(
+      StructField("byteArray", BinaryType)
+    ))
+  }
+
   private def inferSequenceExampleRowType(schemaSoFar: mutable.Map[String, DataType],
                                           next: SequenceExample): mutable.Map[String, DataType] = {
     val featureMap = next.getContext.getFeatureMap.asScala

--- a/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializerTest.scala
+++ b/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordDeserializerTest.scala
@@ -45,6 +45,19 @@ class TFRecordDeserializerTest extends WordSpec with Matchers {
 
   "Deserialize tfrecord to spark internalRow" should {
 
+    "Deserialize ByteArray to internalRow" in {
+      val schema = StructType(Array(
+        StructField("ByteArray", BinaryType)
+      ))
+
+      val byteArray = Array[Byte](0xde.toByte, 0xad.toByte, 0xbe.toByte, 0xef.toByte)
+      val expectedInternalRow = InternalRow(byteArray)
+      val deserializer = new TFRecordDeserializer(schema)
+      val actualInternalRow = deserializer.deserializeByteArray(byteArray)
+
+      assert(actualInternalRow ~== (expectedInternalRow,schema))
+    }
+
     "Serialize tfrecord example to spark internalRow" in {
       val schema = StructType(List(
         StructField("IntegerLabel", IntegerType),
@@ -331,6 +344,5 @@ class TFRecordDeserializerTest extends WordSpec with Matchers {
       assert(actualInternalRow2 ~== (expectedInternalRow2, schema))
 
     }
-
   }
 }


### PR DESCRIPTION
Related Issue: #66 
This is a followup to PR #60 . This can used to read the samples as ByteArrays.(without deserialization)