### PR TITLE
Make datasource option keys case-insensitive

### DIFF
--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/DefaultSource.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/DefaultSource.scala
@@ -32,7 +32,7 @@ class DefaultSource extends FileFormat with DataSourceRegister {
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    val recordType = options.getOrElse("recordType", "Example")
+    val recordType = TFRecordOptions.getOrElse(options, "recordType", "Example")
     files.collectFirst {
       case f if hasSchema(sparkSession, f, recordType) => getSchemaFromFile(sparkSession, f, recordType)
     }

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordFileReader.scala
@@ -19,7 +19,7 @@ object TFRecordFileReader {
     file: PartitionedFile,
     schema: StructType): Iterator[InternalRow] = {
 
-    val recordType = options.getOrElse("recordType", "Example")
+    val recordType = TFRecordOptions.getOrElse(options, "recordType", "Example")
 
     val inputSplit = new FileSplit(
       file.toPath,

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOptions.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOptions.scala
@@ -1,0 +1,10 @@
+package com.linkedin.spark.datasources.tfrecord
+
+private[tfrecord] object TFRecordOptions {
+  def getOrElse(options: Map[String, String], key: String, default: String): String =
+    options.get(key).orElse {
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) => value
+      }
+    }.getOrElse(default)
+}

--- a/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
+++ b/src/main/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOutputWriter.scala
@@ -19,7 +19,7 @@ class TFRecordOutputWriter(
   private val outputStream = CodecStreams.createOutputStream(context, new Path(path))
   private val dataOutputStream = new DataOutputStream(outputStream)
   private val writer = new TFRecordWriter(dataOutputStream)
-  private val recordType = options.getOrElse("recordType", "Example")
+  private val recordType = TFRecordOptions.getOrElse(options, "recordType", "Example")
 
   private[this] val serializer = new TFRecordSerializer(dataSchema)
 

--- a/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordIOSuite.scala
+++ b/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordIOSuite.scala
@@ -181,6 +181,18 @@ class TFRecordIOSuite extends SharedSparkSessionSuite {
       assert(expectedRows === actualRows)
     }
 
+    "Test tfrecord option keys case-insensitively" in {
+
+      val path = s"$TF_SANDBOX_DIR/caseInsensitiveOptions.tfrecord"
+
+      val df: DataFrame = createDataFrameForByteArrayTFRecords()
+      df.write.format("tfrecord").option("recordtype", "ByteArray").save(path)
+
+      val importedDf: DataFrame = spark.read.format("tfrecord").option("recordtype", "ByteArray").load(path)
+
+      assert(df.collect() === importedDf.collect())
+    }
+
     "Test tfrecord write overwrite mode " in {
 
       val path = s"$TF_SANDBOX_DIR/example_overwrite.tfrecord"

--- a/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOptionsSuite.scala
+++ b/src/test/scala/com/linkedin/spark/datasources/tfrecord/TFRecordOptionsSuite.scala
@@ -1,0 +1,25 @@
+package com.linkedin.spark.datasources.tfrecord
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TFRecordOptionsSuite extends FlatSpec with Matchers {
+  "TFRecordOptions" should "resolve option keys case-insensitively" in {
+    TFRecordOptions.getOrElse(
+      Map("recordType" -> "ByteArray"), "recordType", "Example") should be ("ByteArray")
+    TFRecordOptions.getOrElse(
+      Map("recordtype" -> "ByteArray"), "recordType", "Example") should be ("ByteArray")
+    TFRecordOptions.getOrElse(
+      Map("RECORDTYPE" -> "ByteArray"), "recordType", "Example") should be ("ByteArray")
+  }
+
+  it should "prefer the exact key when duplicate casings are present" in {
+    TFRecordOptions.getOrElse(
+      Map("recordType" -> "ByteArray", "RECORDTYPE" -> "Example"),
+      "recordType",
+      "SequenceExample") should be ("ByteArray")
+  }
+
+  it should "return the default when an option is absent" in {
+    TFRecordOptions.getOrElse(Map.empty, "recordType", "Example") should be ("Example")
+  }
+}


### PR DESCRIPTION
## Summary

- Resolve the `recordType` datasource option case-insensitively during schema inference, reads, and writes.
- Preserve the existing exact-key behavior and the `Example` default.
- Add unit coverage and an end-to-end `ByteArray` regression test using the lower-cased `recordtype` key.

## Motivation

Spark datasource option keys are case-insensitive, and newer Spark runtimes can pass normalized lower-case keys to V1 `FileFormat` implementations. The connector previously looked up only the exact `recordType` spelling, so a supplied `recordtype=ByteArray` option silently fell back to `Example`.

## Testing

- `mvn -Pscala-2.12 -Dscala.maven.version=4.9.2 clean test` (37 tests passed)
- `mvn -Pscala-2.13 -Dscala.maven.version=4.9.2 clean test` (37 tests passed)
